### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -40,7 +40,7 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [https://contributor-covenant.org/version/1/4][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reactor Scala Extensions
 [![Join the chat at https://gitter.im/reactor/reactor](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/reactor/reactor?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Reactor Scala Extensions](https://maven-badges.herokuapp.com/maven-central/io.projectreactor/reactor-scala-extensions_2.12/badge.svg?style=plastic)](http://mvnrepository.com/artifact/io.projectreactor/reactor-scala-extensions_2.12)
+[![Reactor Scala Extensions](https://maven-badges.herokuapp.com/maven-central/io.projectreactor/reactor-scala-extensions_2.12/badge.svg?style=plastic)](https://mvnrepository.com/artifact/io.projectreactor/reactor-scala-extensions_2.12)
 [![Download](https://api.bintray.com/packages/sinwe/io.projectreactor/reactor-scala-extensions_2.12/images/download.svg?version=0.3.5) ](https://bintray.com/sinwe/io.projectreactor/reactor-scala-extensions_2.12/0.3.5/link)
 [![Build Status](https://travis-ci.org/reactor/reactor-scala-extensions.svg?branch=master)](https://travis-ci.org/reactor/reactor-scala-extensions)
 [![codecov](https://codecov.io/gh/reactor/reactor-scala-extensions/branch/master/graph/badge.svg)](https://codecov.io/gh/reactor/reactor-scala-extensions)


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [x] http://mvnrepository.com/artifact/io.projectreactor/reactor-scala-extensions_2.12 with 1 occurrences migrated to:  
  https://mvnrepository.com/artifact/io.projectreactor/reactor-scala-extensions_2.12 ([https](https://mvnrepository.com/artifact/io.projectreactor/reactor-scala-extensions_2.12) result 200).
* [x] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [x] http://contributor-covenant.org/version/1/4 with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/4 ([https](https://contributor-covenant.org/version/1/4) result 301).
* [x] http://contributor-covenant.org/version/1/4/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/4/ ([https](https://contributor-covenant.org/version/1/4/) result 301).