### PR TITLE
Fixed null handling in SMono.justOrEmpty

### DIFF
--- a/src/main/scala/reactor/core/scala/publisher/SMono.scala
+++ b/src/main/scala/reactor/core/scala/publisher/SMono.scala
@@ -1440,6 +1440,7 @@ object SMono {
     data match {
       case o: Option[T] => JMono.justOrEmpty[T](o)
       case other: T => JMono.justOrEmpty[T](other)
+      case null => JMono.empty[T]()
     }
   }
 

--- a/src/test/scala/reactor/core/scala/publisher/MonoTest.scala
+++ b/src/test/scala/reactor/core/scala/publisher/MonoTest.scala
@@ -204,6 +204,13 @@ class MonoTest extends FreeSpec with Matchers with TableDrivenPropertyChecks wit
             .expectNext(randomValue)
             .verifyComplete()
         }
+        "just react on completion signal if it is null" in {
+          val nullData:Any = null
+          val mono = Mono.justOrEmpty(nullData)
+          StepVerifier.create(mono)
+            .expectComplete()
+            .verify()
+        }
       }
     }
 

--- a/src/test/scala/reactor/core/scala/publisher/SMonoTest.scala
+++ b/src/test/scala/reactor/core/scala/publisher/SMonoTest.scala
@@ -154,6 +154,13 @@ class SMonoTest extends FreeSpec with Matchers with TestSupport {
             .expectNext(randomValue)
             .verifyComplete()
         }
+        "just react on completion signal if it is null" in {
+          val nullData:Any = null
+          val mono = SMono.justOrEmpty(nullData)
+          StepVerifier.create(mono)
+            .expectComplete()
+            .verify()
+        }
       }
     }
 


### PR DESCRIPTION
While `JMono.justOrEmpty` would handle the null just fine,
it never gets that far because `case other: T` does not match on null values,
resulting in `scala.MatchError: null`

Fixed by adding an explicit null case

Note: `Mono` did not have this problem, but I added the same test there for consistency.