### PR TITLE
Added SFlux counterpart to Flux.flatMap(Function,Int,Int)

### DIFF
--- a/src/main/scala/reactor/core/scala/publisher/SFlux.scala
+++ b/src/main/scala/reactor/core/scala/publisher/SFlux.scala
@@ -450,6 +450,10 @@ trait SFlux[T] extends SFluxLike[T, SFlux] with MapablePublisher[T] with ScalaCo
     if (!delayError) SFlux.fromPublisher(coreFlux.flatMapSequential[R](mapper, maxConcurrency, prefetch))
     else SFlux.fromPublisher(coreFlux.flatMapSequentialDelayError[R](mapper, maxConcurrency, prefetch))
 
+  final def flatMap[R](mapper: T => Publisher[_ <: R], maxConcurrency: Int = SMALL_BUFFER_SIZE, prefetch: Int = XS_BUFFER_SIZE, delayError: Boolean = false): SFlux[R] =
+    if (!delayError) SFlux.fromPublisher(coreFlux.flatMap[R](mapper, maxConcurrency, prefetch))
+    else SFlux.fromPublisher(coreFlux.flatMapDelayError[R](mapper, maxConcurrency, prefetch))
+
 
   final def groupBy[K](keyMapper: T => K): SFlux[GroupedFlux[K, T]] =
     groupBy(keyMapper, identity)


### PR DESCRIPTION
Following what was done with `SFlux.flatMapSequential(...)`, Scala default params are used to allow one method to represent all of these:
* [Flux.flatMap(Function)](https://github.com/reactor/reactor-core/blob/b0aacf2c91dde4ac8f6811b99ca889dd39b5eeee/reactor-core/src/main/java/reactor/core/publisher/Flux.java#L4722)
* [Flux.flatMap(Function, int)](https://github.com/reactor/reactor-core/blob/b0aacf2c91dde4ac8f6811b99ca889dd39b5eeee/reactor-core/src/main/java/reactor/core/publisher/Flux.java#L4764)
* [Flux.flatMap(Function, int, int)](https://github.com/reactor/reactor-core/blob/b0aacf2c91dde4ac8f6811b99ca889dd39b5eeee/reactor-core/src/main/java/reactor/core/publisher/Flux.java#L4810)
* [Flux.flatMapDelayError(Function, int, int)](https://github.com/reactor/reactor-core/blob/b0aacf2c91dde4ac8f6811b99ca889dd39b5eeee/reactor-core/src/main/java/reactor/core/publisher/Flux.java#L4854)