### PR TITLE
SMono.cast/ofType now accept implicit ClassTag instead of Class

### DIFF
--- a/src/main/scala/reactor/core/scala/publisher/SMono.scala
+++ b/src/main/scala/reactor/core/scala/publisher/SMono.scala
@@ -135,6 +135,19 @@ trait SMono[T] extends SMonoLike[T, SMono] with MapablePublisher[T] with ScalaCo
     * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/cast1.png" alt="">
     *
     * @tparam E the [[SMono]] output type
+    * @param clazz the target type to cast to
+    * @return a casted [[SMono]]
+    */
+  @deprecated("Use the other cast signature instead", "reactor-scala-extensions 0.5.0")
+  final def cast[E](clazz: Class[E]): SMono[E] = coreMono.cast(clazz).asScala
+
+  /**
+    * Cast the current [[SMono]] produced type into a target produced type.
+    *
+    * <p>
+    * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/cast1.png" alt="">
+    *
+    * @tparam E the [[SMono]] output type
     * @return a casted [[SMono]]
     */
   final def cast[E](implicit classTag: ClassTag[E]): SMono[E] = coreMono.cast(classTag.runtimeClass.asInstanceOf[Class[E]]).asScala
@@ -743,6 +756,22 @@ trait SMono[T] extends SMonoLike[T, SMono] with MapablePublisher[T] with ScalaCo
     * @return the same sequence, but bearing a name
     */
   final def name(name: String): SMono[T] = coreMono.name(name).asScala
+
+  /**
+    * Evaluate the accepted value against the given [[Class]] type. If the
+    * predicate test succeeds, the value is
+    * passed into the new [[SMono]]. If the predicate test fails, the value is
+    * ignored.
+    *
+    * <p>
+    * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/filter.png" alt="">
+    *
+    * @param clazz the [[Class]] type to test values against
+    * @return a new [[SMono]] reduced to items converted to the matched type
+    */
+  @deprecated("Use the other ofType signature instead", "reactor-scala-extensions 0.5.0")
+  final def ofType[U](clazz: Class[U]): SMono[U] = coreMono.ofType[U](clazz).asScala
+
 
   /**
     * Evaluate the accepted value against the given [[Class]] type. If the

--- a/src/main/scala/reactor/core/scala/publisher/SMono.scala
+++ b/src/main/scala/reactor/core/scala/publisher/SMono.scala
@@ -18,6 +18,7 @@ import reactor.util.function.{Tuple2, Tuple3, Tuple4, Tuple5, Tuple6}
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -134,10 +135,9 @@ trait SMono[T] extends SMonoLike[T, SMono] with MapablePublisher[T] with ScalaCo
     * <img class="marble" src="https://raw.githubusercontent.com/reactor/projectreactor.io/master/src/main/static/assets/img/marble/cast1.png" alt="">
     *
     * @tparam E the [[SMono]] output type
-    * @param clazz the target type to cast to
     * @return a casted [[SMono]]
     */
-  final def cast[E](clazz: Class[E]): SMono[E] = coreMono.cast(clazz).asScala
+  final def cast[E](implicit classTag: ClassTag[E]): SMono[E] = coreMono.cast(classTag.runtimeClass.asInstanceOf[Class[E]]).asScala
 
   /**
     * Turn this [[SMono]] into a hot source and cache last emitted signals for further
@@ -753,10 +753,10 @@ trait SMono[T] extends SMonoLike[T, SMono] with MapablePublisher[T] with ScalaCo
     * <p>
     * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/filter.png" alt="">
     *
-    * @param clazz the [[Class]] type to test values against
+    * @tparam U the [[Class]] type to test values against
     * @return a new [[SMono]] reduced to items converted to the matched type
     */
-  final def ofType[U](clazz: Class[U]): SMono[U] = coreMono.ofType[U](clazz).asScala
+  final def ofType[U](implicit classTag: ClassTag[U]): SMono[U] = coreMono.ofType[U](classTag.runtimeClass.asInstanceOf[Class[U]]).asScala
 
   /**
     * Transform the error emitted by this [[SMono]] by applying a function.

--- a/src/test/scala/reactor/core/scala/publisher/SMonoTest.scala
+++ b/src/test/scala/reactor/core/scala/publisher/SMonoTest.scala
@@ -364,6 +364,10 @@ class SMonoTest extends FreeSpec with Matchers with TestSupport {
       }
     }
 
+    ".cast (deprecated) should cast the underlying value" in {
+      val number = SMono.just(BigDecimal("123")).cast(classOf[ScalaNumber]).block()
+      number shouldBe a[ScalaNumber]
+    }
     ".cast should cast the underlying value" in {
       val number = SMono.just(BigDecimal("123")).cast[ScalaNumber].block()
       number shouldBe a[ScalaNumber]
@@ -804,6 +808,17 @@ class SMonoTest extends FreeSpec with Matchers with TestSupport {
         .verifyComplete()
     }
 
+    ".ofType (deprecated) should" - {
+      "convert the Mono value type to the provided type if it can be casted" in {
+        StepVerifier.create(SMono.just(BigDecimal("1")).ofType(classOf[ScalaNumber]))
+          .expectNextCount(1)
+          .verifyComplete()
+      }
+      "ignore the Mono value if it can't be casted" in {
+        StepVerifier.create(SMono.just(1).ofType(classOf[String]))
+          .verifyComplete()
+      }
+    }
     ".ofType should" - {
       "convert the Mono value type to the provided type if it can be casted" in {
         StepVerifier.create(SMono.just(BigDecimal("1")).ofType[ScalaNumber])

--- a/src/test/scala/reactor/core/scala/publisher/SMonoTest.scala
+++ b/src/test/scala/reactor/core/scala/publisher/SMonoTest.scala
@@ -365,7 +365,7 @@ class SMonoTest extends FreeSpec with Matchers with TestSupport {
     }
 
     ".cast should cast the underlying value" in {
-      val number = SMono.just(BigDecimal("123")).cast(classOf[ScalaNumber]).block()
+      val number = SMono.just(BigDecimal("123")).cast[ScalaNumber].block()
       number shouldBe a[ScalaNumber]
     }
 
@@ -806,12 +806,12 @@ class SMonoTest extends FreeSpec with Matchers with TestSupport {
 
     ".ofType should" - {
       "convert the Mono value type to the provided type if it can be casted" in {
-        StepVerifier.create(SMono.just(BigDecimal("1")).ofType(classOf[ScalaNumber]))
+        StepVerifier.create(SMono.just(BigDecimal("1")).ofType[ScalaNumber])
           .expectNextCount(1)
           .verifyComplete()
       }
       "ignore the Mono value if it can't be casted" in {
-        StepVerifier.create(SMono.just(1).ofType(classOf[String]))
+        StepVerifier.create(SMono.just(1).ofType[String])
           .verifyComplete()
       }
     }


### PR DESCRIPTION
This change allows a user to write code like:
```
myMono.cast[String]
```
... instead of:
```
myMono.cast(classOf[String])
```

SFlux.cast/ofType were already written this way; I merely changed SMono to do it as well.

Note that this would be a breaking change, but perhaps you will agree that this is appropriate for v0.5.0?