### PR TITLE
Added the Publisher apply method to the SFlux object

### DIFF
--- a/src/main/scala/reactor/core/scala/publisher/SFlux.scala
+++ b/src/main/scala/reactor/core/scala/publisher/SFlux.scala
@@ -677,6 +677,8 @@ trait SFlux[T] extends SFluxLike[T, SFlux] with MapablePublisher[T] with ScalaCo
 }
 
 object SFlux {
+  def apply[T](source: Publisher[_ <: T]): SFlux[T] = SFlux.fromPublisher[T](source)
+
   def apply[T](elements: T*): SFlux[T] = SFlux.fromIterable(elements)
 
   def combineLatest[T1, T2](p1: Publisher[T1], p2: Publisher[T2]): SFlux[(T1, T2)] =

--- a/src/test/scala/reactor/core/scala/publisher/SFluxTest.scala
+++ b/src/test/scala/reactor/core/scala/publisher/SFluxTest.scala
@@ -33,7 +33,13 @@ import ScalaConverters._
 
 class SFluxTest extends FreeSpec with Matchers with TableDrivenPropertyChecks with TestSupport {
   "SFlux" - {
-    ".apply should return a proper SFlux" in {
+    ".apply should return a proper SFlux when provided a Publisher" in {
+      StepVerifier.create(SFlux(JFlux.just(1,2,3)))
+        .expectNext(1,2,3)
+        .verifyComplete()
+    }
+
+    ".apply should return a proper SFlux when provided a list of elements" in {
       StepVerifier.create(SFlux(1, 2, 3))
         .expectNext(1, 2, 3)
         .verifyComplete()


### PR DESCRIPTION
Added an apply method to the SFlux object that calls SFlux.fromPublisher. This allows its behavior to match the SMono behavior.