### PR TITLE
Fix conversion to Scala Future

### DIFF
--- a/src/main/scala/reactor/core/scala/publisher/SMono.scala
+++ b/src/main/scala/reactor/core/scala/publisher/SMono.scala
@@ -1300,8 +1300,8 @@ trait SMono[T] extends SMonoLike[T, SMono] with MapablePublisher[T] with ScalaCo
   final def toFuture: Future[T] = {
     val promise = Promise[T]()
     coreMono.toFuture.handle[Unit]((value: T, throwable: Throwable) => {
-      Option(value).foreach(v => promise.complete(Try(v)))
-      Option(throwable).foreach(t => promise.failure(t))
+      if (throwable == null) promise.complete(Success(value))
+      else promise.failure(throwable)
       ()
     })
     promise.future

--- a/src/main/scala/reactor/core/scala/publisher/SMono.scala
+++ b/src/main/scala/reactor/core/scala/publisher/SMono.scala
@@ -1300,8 +1300,10 @@ trait SMono[T] extends SMonoLike[T, SMono] with MapablePublisher[T] with ScalaCo
   final def toFuture: Future[T] = {
     val promise = Promise[T]()
     coreMono.toFuture.handle[Unit]((value: T, throwable: Throwable) => {
-      if (throwable == null) promise.complete(Success(value))
-      else promise.failure(throwable)
+      Option(throwable) match {
+        case Some(_) => promise.failure(throwable)
+        case None => promise.complete(Success(value))
+      }
       ()
     })
     promise.future

--- a/src/test/scala/reactor/core/scala/publisher/SMonoTest.scala
+++ b/src/test/scala/reactor/core/scala/publisher/SMonoTest.scala
@@ -1155,5 +1155,12 @@ class SMonoAsyncTest extends AsyncFreeSpec {
       }
       }
     }
+    ".toFuture should convert this mono to future with void return" in {
+      val future: Future[Int] = SMono.empty[Unit].toFuture.map(_ => 1)
+      future map { v => {
+        assert(v == 1)
+      }
+      }
+    }
   }
 }


### PR DESCRIPTION
Current implementation for future conversion does not work for cases where Mono was completed with a null/void result. 

https://github.com/reactor/reactor-scala-extensions/blob/8ecf0d5fd4fad34b8886499aa03993045e00ce65/src/main/scala/reactor/core/scala/publisher/SMono.scala#L1300-L1308

Here due to use of `Option` with value the promise would not be completed if the value is null. On the other hand the way [Scala Future compat logic][1] handles this by passing a `BiConsumer` which considers the `throwable == null` case as `Success` else a `Failure`

```scala
class P[T](val wrapped: CompletionStage[T]) extends DefaultPromise[T] with BiConsumer[T, Throwable] {
    override def accept(v: T, e: Throwable): Unit = {
      if (e == null) complete(Success(v))
      else complete(Failure(e))
    }
  }
```

As a result this PR fixes the current issue by completing promise with success if throwable is null

[1]: https://github.com/scala/scala-java8-compat/blob/master/src/main/scala/scala/concurrent/java8/FutureConvertersImpl.scala