### PR TITLE
Removed empty param lists from non-side-effecting methods

### DIFF
--- a/src/main/scala/reactor/core/scala/Scannable.scala
+++ b/src/main/scala/reactor/core/scala/Scannable.scala
@@ -12,14 +12,14 @@ import scala.language.implicitConversions
 trait Scannable {
   private[scala] def jScannable: JScannable
 
-  def actuals(): Stream[_ <: Scannable] = jScannable.actuals().iterator().asScala.map(js => js: Scannable).toStream
+  def actuals: Stream[_ <: Scannable] = jScannable.actuals().iterator().asScala.map(js => js: Scannable).toStream
 
-  def inners(): Stream[_ <: Scannable] = jScannable.inners().iterator().asScala.map(js => js: Scannable).toStream
+  def inners: Stream[_ <: Scannable] = jScannable.inners().iterator().asScala.map(js => js: Scannable).toStream
 
   def isScanAvailable: Boolean = jScannable.isScanAvailable
 
   /**
-    * Check this [[Scannable]] and its [[Scannable.parents()]] for a name an return the
+    * Check this [[Scannable]] and its [[Scannable.parents]] for a name an return the
     * first one that is reachable.
     *
     * @return the name of the first parent that has one defined (including this scannable)
@@ -80,7 +80,7 @@ trait Scannable {
   def scanOrDefault[T](key: Attr[T], defaultValue: T): T = jScannable.scanOrDefault(key, defaultValue)
 
   /**
-    * Visit this [[Scannable]] and its [[Scannable.parents()]] and stream all the
+    * Visit this [[Scannable]] and its [[Scannable.parents]] and stream all the
     * observed tags
     *
     * @return the stream of tags for this [[Scannable]] and its parents

--- a/src/main/scala/reactor/core/scala/publisher/ConnectableSFlux.scala
+++ b/src/main/scala/reactor/core/scala/publisher/ConnectableSFlux.scala
@@ -51,7 +51,7 @@ class ConnectableSFlux[+T]private(private val connectableFlux: ConnectableFlux[_
     *
     * @return a reference counting [[SFlux]]
     */
-  final def refCount(): SFlux[T] = SFlux.fromPublisher(connectableFlux.refCount())
+  final def refCount: SFlux[T] = SFlux.fromPublisher(connectableFlux.refCount())
 
   /**
     * Connects to the upstream source when the given number of [[org.reactivestreams.Subscriber]] subscribes and disconnects

--- a/src/main/scala/reactor/core/scala/publisher/FluxProcessor.scala
+++ b/src/main/scala/reactor/core/scala/publisher/FluxProcessor.scala
@@ -33,7 +33,7 @@ trait FluxProcessor[IN, OUT] extends SFlux[OUT] with Processor[IN, OUT] with Dis
     *
     * @return processor buffer capacity if any or [[Int.MaxValue]]
     */
-  def bufferSize(): Int = jFluxProcessor.getBufferSize
+  def bufferSize: Int = jFluxProcessor.getBufferSize
 
   /**
     * Current error if any, default to [[None]]
@@ -63,7 +63,7 @@ trait FluxProcessor[IN, OUT] extends SFlux[OUT] with Processor[IN, OUT] with Dis
     */
   def hasError: Boolean = jFluxProcessor.hasError
 
-  override def inners(): Stream[_ <: Scannable] = jFluxProcessor.inners().iterator().asScala.map(js=> js: Scannable).toStream
+  override def inners: Stream[_ <: Scannable] = jFluxProcessor.inners().iterator().asScala.map(js=> js: Scannable).toStream
 
   /**
     * Has this upstream finished or "completed" / "failed" ?
@@ -86,7 +86,7 @@ trait FluxProcessor[IN, OUT] extends SFlux[OUT] with Processor[IN, OUT] with Dis
     *
     * @return a serializing [[FluxProcessor]]
     */
-  final def serialize(): FluxProcessor[IN, OUT] = new ReactiveSFlux[OUT](jFluxProcessor) with FluxProcessor[IN, OUT] {
+  final def serialize: FluxProcessor[IN, OUT] = new ReactiveSFlux[OUT](jFluxProcessor) with FluxProcessor[IN, OUT] {
     override protected def jFluxProcessor: JFluxProcessor[IN, OUT] = jFluxProcessor.serialize()
 
     override val jScannable: core.Scannable = jFluxProcessor
@@ -95,7 +95,10 @@ trait FluxProcessor[IN, OUT] extends SFlux[OUT] with Processor[IN, OUT] with Dis
   /**
     * Create a [[FluxSink]] that safely gates multi-threaded producer
     * [[Subscriber.onNext]].
-    *
+    * 
+    * <p> This processor will be subscribed to that [[FluxSink]],
+    * and any previous subscribers will be unsubscribed.
+    * 
     * <p> The returned [[FluxSink]] will not apply any
     * [[FluxSink.OverflowStrategy]] and overflowing [[FluxSink.next]]
     * will behave in two possible ways depending on the Processor:
@@ -165,7 +168,7 @@ object FluxProcessor {
     * @tparam T the produced type
     * @return a [[FluxProcessor]] accepting publishers and producing T
     */
-  def switchOnNext[T](): FluxProcessor[Publisher[_ <: T], T] = {
+  def switchOnNext[T]: FluxProcessor[Publisher[_ <: T], T] = {
     val emitter = new UnicastProcessor[Publisher[_ <: T]](JUnicastProcessor.create())
     wrap[Publisher[_ <: T], T](emitter, SFlux.switchOnNext[T](emitter))
   }

--- a/src/main/scala/reactor/core/scala/publisher/SFlux.scala
+++ b/src/main/scala/reactor/core/scala/publisher/SFlux.scala
@@ -82,7 +82,7 @@ trait SFlux[+T] extends SFluxLike[T] with MapablePublisher[T] with ScalaConverte
     coreFlux.as[P]((t: JFlux[_ <: T]) => transformer(SFlux.fromPublisher(t)))
   }
 
-  final def asJava(): JFlux[_ <: T] = coreFlux
+  final def asJava: JFlux[_ <: T] = coreFlux
 
   /**
     * Blocks until the upstream signals its first value or completes.
@@ -342,7 +342,7 @@ trait SFlux[+T] extends SFluxLike[T] with MapablePublisher[T] with ScalaConverte
 
   final def collect[E](containerSupplier: () => E, collector: (E, T) => Unit): SMono[E] = coreFlux.collect(containerSupplier, collector: JBiConsumer[E, T]).asScala
 
-  final def collectSeq(): SMono[Seq[T]] = new ReactiveSMono[Seq[T]](coreFlux.collectList().map((l: JList[_ <: T]) => l.asScala.toSeq))
+  final def collectSeq: SMono[Seq[T]] = new ReactiveSMono[Seq[T]](coreFlux.collectList().map((l: JList[_ <: T]) => l.asScala.toSeq))
 
   final def concatMap[V](mapper: T => Publisher[_ <: V], prefetch: Int = XS_BUFFER_SIZE): SFlux[V] = coreFlux.concatMap[V](mapper, prefetch).asScala
 
@@ -391,7 +391,7 @@ trait SFlux[+T] extends SFluxLike[T] with MapablePublisher[T] with ScalaConverte
 
   private[publisher] def coreFlux: JFlux[_ <: T]
 
-  final def count(): SMono[Long] = coreFlux.count().asScala.map(jl => Long2long(jl))
+  final def count: SMono[Long] = coreFlux.count().asScala.map(jl => Long2long(jl))
 
   /**
     * Provide a default unique value if this sequence is completed without any data
@@ -427,13 +427,13 @@ trait SFlux[+T] extends SFluxLike[T] with MapablePublisher[T] with ScalaConverte
 
   final def delaySubscription[U](subscriptionDelay: Publisher[U]): SFlux[T] = new ReactiveSFlux(coreFlux.delaySubscription(subscriptionDelay))
 
-  final def dematerialize[X](): SFlux[X] = new ReactiveSFlux[X](coreFlux.dematerialize[X]())
+  final def dematerialize[X]: SFlux[X] = new ReactiveSFlux[X](coreFlux.dematerialize[X]())
 
-  final def distinct(): SFlux[T] = distinct(identity)
+  final def distinct: SFlux[T] = distinct(identity)
 
   final def distinct[V](keySelector: T => V): SFlux[T] = new ReactiveSFlux(coreFlux.distinct[V](keySelector))
 
-  final def distinctUntilChanged(): SFlux[T] = distinctUntilChanged(identity)
+  final def distinctUntilChanged: SFlux[T] = distinctUntilChanged(identity)
 
   final def distinctUntilChanged[V](keySelector: T => V, keyComparator: (V, V) => Boolean = (x: V, y: V) => x == y): SFlux[T] = new ReactiveSFlux(coreFlux.distinctUntilChanged[V](keySelector, keyComparator))
 
@@ -555,9 +555,9 @@ trait SFlux[+T] extends SFluxLike[T] with MapablePublisher[T] with ScalaConverte
 
   final def hasElements: SMono[Boolean] = new ReactiveSMono[JBoolean](coreFlux.hasElements()).map(Boolean2boolean)
 
-  final def ignoreElements(): SMono[T] = SMono.fromPublisher(coreFlux.ignoreElements())
+  final def ignoreElements: SMono[T] = SMono.fromPublisher(coreFlux.ignoreElements())
 
-  final def index(): SFlux[(Long, T)] = index[(Long, T)]((x, y) => (x, y))
+  final def index: SFlux[(Long, T)] = index[(Long, T)]((x, y) => (x, y))
 
   final def index[I](indexMapper: (Long, T) => I): SFlux[I] = new ReactiveSFlux[I](coreFlux.index[I]((t: JLong, u: T) => indexMapper(Long2long(t), u)))
 
@@ -597,7 +597,7 @@ trait SFlux[+T] extends SFluxLike[T] with MapablePublisher[T] with ScalaConverte
     */
   override final def map[V](mapper: T => V): SFlux[V] = SFlux.fromPublisher(coreFlux.map[V](mapper))
 
-  final def materialize(): SFlux[Signal[_ <: T]] = SFlux.fromPublisher(coreFlux.materialize())
+  final def materialize: SFlux[Signal[_ <: T]] = SFlux.fromPublisher(coreFlux.materialize())
 
   final def mergeWith[U >: T](other: Publisher[U]): SFlux[U] = SFlux.fromPublisher(coreFlux.mergeWith(other.asInstanceOf[Publisher[Nothing]]))
 
@@ -614,13 +614,13 @@ trait SFlux[+T] extends SFluxLike[T] with MapablePublisher[T] with ScalaConverte
 
   final def name(name: String): SFlux[T] = SFlux.fromPublisher(coreFlux.name(name))
 
-  final def next(): SMono[T] = SMono.fromPublisher(coreFlux.next())
+  final def next: SMono[T] = SMono.fromPublisher(coreFlux.next())
 
   final def nonEmpty: SMono[Boolean] = hasElements
 
   final def ofType[U](implicit classTag: ClassTag[U]): SFlux[U] = SFlux.fromPublisher(coreFlux.ofType(classTag.runtimeClass.asInstanceOf[Class[U]]))
 
-  final def onBackpressureBuffer(): SFlux[T] = SFlux.fromPublisher(coreFlux.onBackpressureBuffer())
+  final def onBackpressureBuffer: SFlux[T] = SFlux.fromPublisher(coreFlux.onBackpressureBuffer())
 
   final def onBackpressureBuffer(maxSize: Int): SFlux[T] = SFlux.fromPublisher(coreFlux.onBackpressureBuffer(maxSize))
 
@@ -630,13 +630,13 @@ trait SFlux[+T] extends SFluxLike[T] with MapablePublisher[T] with ScalaConverte
 
   final def onBackpressureBuffer(maxSize: Int, onBufferOverflow: T => Unit, bufferOverflowStrategy: BufferOverflowStrategy): SFlux[T] = SFlux.fromPublisher(coreFlux.onBackpressureBuffer(maxSize, onBufferOverflow, bufferOverflowStrategy))
 
-  final def onBackpressureDrop(): SFlux[T] = SFlux.fromPublisher(coreFlux.onBackpressureDrop())
+  final def onBackpressureDrop: SFlux[T] = SFlux.fromPublisher(coreFlux.onBackpressureDrop())
 
   final def onBackpressureDrop(onDropped: T => Unit): SFlux[T] = SFlux.fromPublisher(coreFlux.onBackpressureDrop(onDropped))
 
-  final def onBackpressureError(): SFlux[T] = SFlux.fromPublisher(coreFlux.onBackpressureError())
+  final def onBackpressureError: SFlux[T] = SFlux.fromPublisher(coreFlux.onBackpressureError())
 
-  final def onBackpressureLatest(): SFlux[T] = SFlux.fromPublisher(coreFlux.onBackpressureLatest())
+  final def onBackpressureLatest: SFlux[T] = SFlux.fromPublisher(coreFlux.onBackpressureLatest())
 
   final def onErrorMap(mapper: Throwable => _ <: Throwable): SFlux[T] = SFlux.fromPublisher(coreFlux.onErrorMap(mapper))
 
@@ -688,7 +688,7 @@ trait SFlux[+T] extends SFluxLike[T] with MapablePublisher[T] with ScalaConverte
     *
     * @return a new [[SMono]]
     */
-  final def publishNext(): SMono[T] = SMono.fromPublisher(coreFlux.publishNext())
+  final def publishNext: SMono[T] = SMono.fromPublisher(coreFlux.publishNext())
 
   final def reduce[A](initial: A)(accumulator: (A, T) => A): SMono[A] = coreFlux.reduce[A](initial, accumulator).asScala
 
@@ -756,7 +756,7 @@ trait SFlux[+T] extends SFluxLike[T] with MapablePublisher[T] with ScalaConverte
     * }</pre>
     * </blockquote>
     *
-    * @param retrySpec the { @link Retry} strategy that will generate the companion { @link Publisher},
+    * @param retry the { @link Retry} strategy that will generate the companion { @link Publisher},
     *                              given a { @link Flux} that signals each onError as a { @link reactor.util.retry.Retry.RetrySignal}.
     * @return a { @link Flux} that retries on onError when a companion { @link Publisher} produces an onNext signal
     * @see Retry.max(long)
@@ -878,7 +878,7 @@ trait SFlux[+T] extends SFluxLike[T] with MapablePublisher[T] with ScalaConverte
       .getOrElse (coreFlux.single()).asScala
   }
 
-  final def singleOrEmpty(): SMono[T] = coreFlux.singleOrEmpty().asScala
+  final def singleOrEmpty: SMono[T] = coreFlux.singleOrEmpty().asScala
 
   final def skip(skipped: Long): SFlux[T] = coreFlux.skip(skipped).asScala
 
@@ -890,7 +890,7 @@ trait SFlux[+T] extends SFluxLike[T] with MapablePublisher[T] with ScalaConverte
 
   final def skipWhile(skipPredicate: T => Boolean): SFlux[T] = coreFlux.skipWhile(skipPredicate).asScala
 
-  final def sort(): SFlux[T] = coreFlux.sort().asScala
+  final def sort: SFlux[T] = coreFlux.sort().asScala
 
   final def sort[U >: T](sortFunction: Ordering[U]): SFlux[U] = coreFlux.sort(sortFunction).asScala
 
@@ -977,7 +977,7 @@ trait SFlux[+T] extends SFluxLike[T] with MapablePublisher[T] with ScalaConverte
 
   final def takeWhile(continuePredicate: T => Boolean): SFlux[T] = coreFlux.takeWhile(continuePredicate).asScala
 
-  final def `then`(): SMono[Unit] = new ReactiveSMono(coreFlux.`then`()).map(_ => ())
+  final def `then`: SMono[Unit] = new ReactiveSMono(coreFlux.`then`()).map(_ => ())
 
   final def thenEmpty(other: MapablePublisher[Unit]): SMono[Unit] = new ReactiveSMono(
     coreFlux.thenEmpty(publisherUnit2PublisherVoid(other))).map(_ => ())
@@ -1165,7 +1165,7 @@ object SFlux {
       if (delayError) JFlux.mergeSequentialDelayError[I](sources, maxConcurrency, prefetch)
       else JFlux.mergeSequential[I](sources, maxConcurrency, prefetch))
 
-  def never[T](): SFlux[T] = new ReactiveSFlux[T](JFlux.never[T]())
+  def never[T]: SFlux[T] = new ReactiveSFlux[T](JFlux.never[T]())
 
   def push[T](emitter: FluxSink[T] => Unit, backPressure: FluxSink.OverflowStrategy = OverflowStrategy.BUFFER): SFlux[T] = new ReactiveSFlux[T](JFlux.push(emitter, backPressure))
 

--- a/src/main/scala/reactor/core/scala/publisher/SGroupedFlux.scala
+++ b/src/main/scala/reactor/core/scala/publisher/SGroupedFlux.scala
@@ -14,7 +14,7 @@ class SGroupedFlux[K, V]private(private val jGroupedFlux: JGroupedFlux[K, V]) ex
     * Return defined identifier
     * @return defined identifier
     */
-  def key(): K = jGroupedFlux.key()
+  def key: K = jGroupedFlux.key()
 
   override private[publisher] def coreFlux: JGroupedFlux[K, V] = jGroupedFlux
 }

--- a/src/main/scala/reactor/core/scala/publisher/SMono.scala
+++ b/src/main/scala/reactor/core/scala/publisher/SMono.scala
@@ -2,14 +2,14 @@ package reactor.core.scala.publisher
 
 import java.lang.{Boolean => JBoolean, Long => JLong}
 import java.util.concurrent.{Callable, CompletableFuture}
-import java.util.function.{Consumer, Function, Supplier}
+import java.util.function.Function
 import java.util.logging.Level
 
 import org.reactivestreams.{Publisher, Subscriber, Subscription}
 import reactor.core.publisher.{MonoSink, Signal, SignalType, SynchronousSink, Flux => JFlux, Mono => JMono}
 import reactor.core.scala.Scannable
 import reactor.core.scheduler.{Scheduler, Schedulers}
-import reactor.core.{Disposable, Scannable => JScannable}
+import reactor.core.{Disposable}
 import reactor.util.concurrent.Queues.SMALL_BUFFER_SIZE
 import reactor.util.context.Context
 import reactor.util.function.{Tuple2, Tuple3, Tuple4, Tuple5, Tuple6}
@@ -86,7 +86,7 @@ trait SMono[+T] extends SMonoLike[T] with MapablePublisher[T] with ScalaConverte
     *
     * @return [[reactor.core.publisher.Mono]]
     */
-  final def asJava(): JMono[_ <: T] = coreMono
+  final def asJava: JMono[_ <: T] = coreMono
 
   /**
     * Block until a next signal is received, will return null if onComplete, T if onNext, throw a
@@ -295,7 +295,7 @@ trait SMono[+T] extends SMonoLike[T] with MapablePublisher[T] with ScalaConverte
     * @tparam X the dematerialized type
     * @return a dematerialized [[SMono]]
     */
-  final def dematerialize[X](): SMono[X] = coreMono.dematerialize[X]().asScala
+  final def dematerialize[X]: SMono[X] = coreMono.dematerialize[X]().asScala
 
   /**
     * Triggered after the [[SMono]] terminates, either by completing downstream successfully or with an error.
@@ -639,7 +639,7 @@ trait SMono[+T] extends SMonoLike[T] with MapablePublisher[T] with ScalaConverte
     *
     * @return a [[SFlux]] variant of this [[SMono]]
     */
-  final def flux(): SFlux[T] = coreMono.flux().asScala
+  final def flux: SFlux[T] = coreMono.flux().asScala
 
   /**
     * Emit a single boolean true if this [[SMono]] has an element.
@@ -733,7 +733,7 @@ trait SMono[+T] extends SMonoLike[T] with MapablePublisher[T] with ScalaConverte
     * @return a [[SMono]] of materialized [[Signal]]
     * @see [[SMono.dematerialize()]]
     */
-  final def materialize(): SMono[Signal[_ <: T]] = coreMono.materialize().asScala
+  final def materialize: SMono[Signal[_ <: T]] = coreMono.materialize().asScala
 
   /**
     * Merge emissions of this [[SMono]] with the provided [[Publisher]].
@@ -844,7 +844,7 @@ trait SMono[+T] extends SMonoLike[T] with MapablePublisher[T] with ScalaConverte
     *
     * @return a detachable [[SMono]]
     */
-  final def onTerminateDetach(): SMono[T] = coreMono.onTerminateDetach().asScala
+  final def onTerminateDetach: SMono[T] = coreMono.onTerminateDetach().asScala
 
   /**
     * Emit the any of the result from this mono or from the given mono
@@ -993,7 +993,7 @@ trait SMono[+T] extends SMonoLike[T] with MapablePublisher[T] with ScalaConverte
     *
     * @return a [[SMono]] with the single item or an error signal
     */
-  final def single(): SMono[T] = coreMono.single().asScala
+  final def single: SMono[T] = coreMono.single().asScala
 
   /**
     * Subscribe to this [[SMono]] and request unbounded demand.
@@ -1207,7 +1207,7 @@ trait SMono[+T] extends SMonoLike[T] with MapablePublisher[T] with ScalaConverte
     *
     * @return a [[SMono]] ignoring its payload (actively dropping)
     */
-  final def `then`(): SMono[Unit] = new ReactiveSMono[Unit](coreMono.`then`().map((_: Void) => ()))
+  final def `then`: SMono[Unit] = new ReactiveSMono[Unit](coreMono.`then`().map((_: Void) => ()))
 
   /**
     * Ignore element from this [[SMono]] and transform its completion signal into the
@@ -1431,7 +1431,7 @@ object SMono extends ScalaConverters {
     */
   def create[T](callback: MonoSink[T] => Unit): SMono[T] = JMono.create[T](callback).asScala
 
-  def defer[T](supplier: () => SMono[T]): SMono[T] = SMono.fromPublisher(JMono.defer[T](() => supplier().asJava()))
+  def defer[T](supplier: () => SMono[T]): SMono[T] = SMono.fromPublisher(JMono.defer[T](() => supplier().asJava))
 
   def delay(duration: Duration, timer: Scheduler = Schedulers.parallel()): SMono[Long] = JMono.delay(duration, timer).asScala.map(jl => Long2long(jl))
 
@@ -1448,7 +1448,7 @@ object SMono extends ScalaConverters {
     * @tparam T The type of the function result.
     * @return a [[SMono]].
     */
-  def firstEmitter[T](monos: SMono[_ <: T]*): SMono[T] = JMono.first[T](monos.map(_.asJava()): _*).asScala
+  def firstEmitter[T](monos: SMono[_ <: T]*): SMono[T] = JMono.first[T](monos.map(_.asJava): _*).asScala
 
   def fromPublisher[T](source: Publisher[_ <: T]): SMono[T] = JMono.from[T](source).asScala
 
@@ -1503,7 +1503,7 @@ object SMono extends ScalaConverters {
     * @return a new [[SMono]] emitting current context
     * @see [[SMono.subscribe(CoreSubscriber)]]
     */
-  def subscribeContext(): SMono[Context] = JMono.subscriberContext().asScala
+  def subscribeContext: SMono[Context] = JMono.subscriberContext().asScala
 
   @deprecated("Use error(Throwable) instead")
   def raiseError[T](exception: Throwable): SMono[T] = error(exception)
@@ -1586,7 +1586,7 @@ object SMono extends ScalaConverters {
   )
 
   def zipDelayError[R](monos: Iterable[_ <: SMono[_]], combinator: Array[AnyRef] => _ <: R): SMono[R] = {
-    new ReactiveSMono[R](JMono.zipDelayError[R](monos.map(_.asJava()).asJava, new Function[Array[AnyRef], R] {
+    new ReactiveSMono[R](JMono.zipDelayError[R](monos.map(_.asJava).asJava, new Function[Array[AnyRef], R] {
       override def apply(t: Array[AnyRef]): R = {
         val v = t.map { v => v: AnyRef }
         combinator(v)
@@ -1601,13 +1601,13 @@ object SMono extends ScalaConverters {
         combinator(v)
       }
     }
-    new ReactiveSMono[R](JMono.zipDelayError[R](combinatorFunction, monos.map(_.asJava()): _*))
+    new ReactiveSMono[R](JMono.zipDelayError[R](combinatorFunction, monos.map(_.asJava): _*))
   }
 
-  def zip[R](combinator: Array[AnyRef] => R, monos: SMono[_]*): SMono[R] = new ReactiveSMono[R](JMono.zip(combinator, monos.map(_.asJava()).toArray: _*))
+  def zip[R](combinator: Array[AnyRef] => R, monos: SMono[_]*): SMono[R] = new ReactiveSMono[R](JMono.zip(combinator, monos.map(_.asJava).toArray: _*))
 
   def zip[R](monos: Iterable[_ <: SMono[_]], combinator: Array[AnyRef] => R): SMono[R] =
-    new ReactiveSMono[R](JMono.zip(monos.map(_.asJava()).asJava, new Function[Array[Object], R] {
+    new ReactiveSMono[R](JMono.zip(monos.map(_.asJava).asJava, new Function[Array[Object], R] {
       override def apply(t: Array[Object]) = combinator(t.map { v => Option(v): Option[AnyRef] }.filterNot(_.isEmpty).map(_.getOrElse(None.orNull)))
     }))
 }

--- a/src/main/scala/reactor/core/scala/publisher/UnicastProcessor.scala
+++ b/src/main/scala/reactor/core/scala/publisher/UnicastProcessor.scala
@@ -41,5 +41,5 @@ object UnicastProcessor {
     * @tparam T the relayed type
     * @return a unicast [[FluxProcessor]]
     */
-  def create[T](): UnicastProcessor[T] = apply[T](JUnicastProcessor.create[T]())
+  def create[T]: UnicastProcessor[T] = apply[T](JUnicastProcessor.create[T]())
 }

--- a/src/test/scala/reactor/core/scala/publisher/SFluxTest.scala
+++ b/src/test/scala/reactor/core/scala/publisher/SFluxTest.scala
@@ -199,7 +199,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
 
     ".index" - {
       "should return tuple with the index" in {
-        val flux = SFlux("a", "b", "c").index()
+        val flux = SFlux("a", "b", "c").index
         StepVerifier.create(flux)
           .expectNext((0L, "a"), (1L, "b"), (2L, "c"))
           .verifyComplete()
@@ -370,7 +370,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
     }
 
     ".never should never emit any signal" in {
-      StepVerifier.create(SFlux.never())
+      StepVerifier.create(SFlux.never)
         .expectSubscription()
         .expectNoEvent(Duration(1, "second"))
     }
@@ -801,7 +801,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
     }
 
     ".collectList should collect the value into a sequence" in {
-      StepVerifier.create(SFlux.just(1, 2, 3).collectSeq())
+      StepVerifier.create(SFlux.just(1, 2, 3).collectSeq)
         .expectNext(Seq(1, 2, 3))
         .verifyComplete()
     }
@@ -926,7 +926,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
     }
 
     ".count should return Mono which emit the number of value in this flux" in {
-      StepVerifier.create(SFlux.just(10, 9, 8).count())
+      StepVerifier.create(SFlux.just(10, 9, 8).count)
         .expectNext(3)
         .verifyComplete()
     }
@@ -964,7 +964,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
     }
 
     ".dematerialize should dematerialize the underlying flux" in {
-      StepVerifier.create(SFlux.just(Signal.next(1), Signal.next(2)).dematerialize())
+      StepVerifier.create(SFlux.just(Signal.next(1), Signal.next(2)).dematerialize)
         .expectNext(1, 2)
         .verifyComplete
     }
@@ -987,7 +987,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
 
     ".distinct" - {
       "should make the flux distinct" in {
-        StepVerifier.create(SFlux.just(1, 2, 3, 2, 4, 3, 6).distinct())
+        StepVerifier.create(SFlux.just(1, 2, 3, 2, 4, 3, 6).distinct)
           .expectNext(1, 2, 3, 4, 6)
           .verifyComplete()
       }
@@ -1000,7 +1000,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
 
     ".distinctUntilChanged" - {
       "should make the flux always return different subsequent value" in {
-        StepVerifier.create(SFlux.just(1, 2, 2, 3, 3, 3, 3, 2, 2, 5).distinctUntilChanged())
+        StepVerifier.create(SFlux.just(1, 2, 2, 3, 3, 3, 3, 2, 2, 5).distinctUntilChanged)
           .expectNext(1, 2, 3, 2, 5)
           .verifyComplete()
       }
@@ -1347,11 +1347,11 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
         })
           .expectNextMatches((t: SGroupedFlux[String, _ <: Int]) => {
             t.subscribe(x => oddBuffer append x)
-            t.key() == "odd"
+            t.key == "odd"
           })
           .expectNextMatches((t: SGroupedFlux[String, _ <: Int]) => {
             t.subscribe(x => evenBuffer append x)
-            t.key() == "even"
+            t.key == "even"
           })
           .verifyComplete()
 
@@ -1368,11 +1368,11 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
         }: Int => String, identity, 6))
           .expectNextMatches((t: SGroupedFlux[String, Int]) => {
             t.subscribe(x => oddBuffer append x)
-            t.key() == "odd"
+            t.key == "odd"
           })
           .expectNextMatches((t: SGroupedFlux[String, Int]) => {
             t.subscribe(x => evenBuffer append x)
-            t.key() == "even"
+            t.key == "even"
           })
           .verifyComplete()
 
@@ -1390,11 +1390,11 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
         }: Int => String, (i => i.toString): Int => String))
           .expectNextMatches((t: SGroupedFlux[String, String]) => {
             t.subscribe(x => oddBuffer append x)
-            t.key() == "odd"
+            t.key == "odd"
           })
           .expectNextMatches((t: SGroupedFlux[String, String]) => {
             t.subscribe(x => evenBuffer append x)
-            t.key() == "even"
+            t.key == "even"
           })
           .verifyComplete()
 
@@ -1412,11 +1412,11 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
         }: Int => String, (i => i.toString): Int => String, 6))
           .expectNextMatches((t: SGroupedFlux[String, String]) => {
             t.subscribe(x => oddBuffer append x)
-            t.key() == "odd"
+            t.key == "odd"
           })
           .expectNextMatches((t: SGroupedFlux[String, String]) => {
             t.subscribe(x => evenBuffer append x)
-            t.key() == "even"
+            t.key == "even"
           })
           .verifyComplete()
 
@@ -1461,7 +1461,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
     }
 
     ".ignoreElements should ignore all elements and only reacts on termination" in {
-      StepVerifier.create(SFlux.just(1, 2, 3).ignoreElements())
+      StepVerifier.create(SFlux.just(1, 2, 3).ignoreElements)
         .verifyComplete()
     }
 
@@ -1496,7 +1496,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
     }
 
     ".materialize should convert the flux into a flux that emit its signal" in {
-      StepVerifier.create(SFlux.just(1, 2, 3).materialize())
+      StepVerifier.create(SFlux.just(1, 2, 3).materialize)
         .expectNext(Signal.next(1), Signal.next(2), Signal.next(3), Signal.complete[Int]())
         .verifyComplete()
     }
@@ -1561,7 +1561,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
     }
 
     ".next should emit only the first item" in {
-      StepVerifier.create(SFlux.just(1, 2, 3).next())
+      StepVerifier.create(SFlux.just(1, 2, 3).next)
         .expectNext(1)
         .verifyComplete()
     }
@@ -1582,7 +1582,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
       "should call the underlying method" in {
         val jFlux = spy(JFlux.just(1, 2, 3))
         val flux = SFlux.fromPublisher(jFlux)
-        flux.onBackpressureBuffer()
+        flux.onBackpressureBuffer
         jFlux.onBackpressureBuffer() was called
       }
       "with maxSize should call the underlying method" in {
@@ -1615,7 +1615,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
       val jFlux = spy(JFlux.just(1, 2, 3))
       val flux = SFlux.fromPublisher(jFlux)
       "without consumer" in {
-        flux.onBackpressureDrop()
+        flux.onBackpressureDrop
         jFlux.onBackpressureDrop() was called
       }
       "with consumer" in {
@@ -1627,14 +1627,14 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
     ".onBackpressureError" in {
       val jFlux = spy(JFlux.just(1, 2, 3))
       val flux = SFlux.fromPublisher(jFlux)
-      flux.onBackpressureError()
+      flux.onBackpressureError
       jFlux.onBackpressureError() was called
     }
 
     ".onBackpressureLatest" in {
       val jFlux = spy(JFlux.just(1, 2, 3))
       val flux = SFlux.fromPublisher(jFlux)
-      flux.onBackpressureLatest()
+      flux.onBackpressureLatest
       jFlux.onBackpressureLatest() was called
     }
 
@@ -1733,7 +1733,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
     }
 
     ".publishNext should make this flux a hot mono" in {
-      StepVerifier.create(SFlux.just(1, 2, 3).publishNext())
+      StepVerifier.create(SFlux.just(1, 2, 3).publishNext)
         .expectNext(1)
         .verifyComplete()
     }
@@ -1917,7 +1917,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
     }
 
     ".singleOrEmpty should return mono with single value or empty" in {
-      StepVerifier.create(SFlux.just(3).singleOrEmpty())
+      StepVerifier.create(SFlux.just(3).singleOrEmpty)
         .expectNext(3)
         .verifyComplete()
     }
@@ -1962,7 +1962,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
 
     ".sort" - {
       "should sort the elements" in {
-        StepVerifier.create(SFlux.just(3, 4, 2, 5, 1, 6).sort())
+        StepVerifier.create(SFlux.just(3, 4, 2, 5, 1, 6).sort)
           .expectNext(1, 2, 3, 4, 5, 6)
           .verifyComplete()
       }
@@ -2079,7 +2079,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
 
     ".then" - {
       "without parameter should actively ignore the values" in {
-        StepVerifier.create(SFlux.just(1, 2, 3, 4, 5).`then`())
+        StepVerifier.create(SFlux.just(1, 2, 3, 4, 5).`then`)
           .verifyComplete()
       }
     }
@@ -2217,7 +2217,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
     }
 
     ".asJava should convert to java" in {
-      SFlux.just(1, 2, 3).asJava() shouldBe a[reactor.core.publisher.Flux[_]]
+      SFlux.just(1, 2, 3).asJava shouldBe a[reactor.core.publisher.Flux[_]]
     }
   }
 }

--- a/src/test/scala/reactor/core/scala/publisher/SMonoTest.scala
+++ b/src/test/scala/reactor/core/scala/publisher/SMonoTest.scala
@@ -365,7 +365,7 @@ class SMonoTest extends AnyFreeSpec with Matchers with TestSupport with Idiomati
     }
 
     ".asJava should convert to java" in {
-      just(randomValue).asJava() shouldBe a[JMono[_]]
+      just(randomValue).asJava shouldBe a[JMono[_]]
     }
 
     ".asScala should transform Mono to SMono" in {
@@ -548,7 +548,7 @@ class SMonoTest extends AnyFreeSpec with Matchers with TestSupport with Idiomati
     }
 
     ".dematerialize should dematerialize the underlying mono" in {
-      StepVerifier.create(just(Signal.next(randomValue)).dematerialize())
+      StepVerifier.create(just(Signal.next(randomValue)).dematerialize)
         .expectNext(randomValue)
         .verifyComplete()
     }
@@ -762,7 +762,7 @@ class SMonoTest extends AnyFreeSpec with Matchers with TestSupport with Idiomati
     }
 
     ".flux should convert this mono into a flux" in {
-      val flux = just(randomValue).flux()
+      val flux = just(randomValue).flux
       StepVerifier.create(flux)
         .expectNext(randomValue)
         .verifyComplete()
@@ -860,7 +860,7 @@ class SMonoTest extends AnyFreeSpec with Matchers with TestSupport with Idiomati
     }
 
     ".materialize should convert the mono into a mono that emit its signal" in {
-      StepVerifier.create(just(randomValue).materialize())
+      StepVerifier.create(just(randomValue).materialize)
         .expectNext(Signal.next(randomValue))
         .verifyComplete()
     }
@@ -1028,12 +1028,12 @@ class SMonoTest extends AnyFreeSpec with Matchers with TestSupport with Idiomati
 
     ".single" - {
       "should enforce the existence of element" in {
-        StepVerifier.create(just(randomValue).single())
+        StepVerifier.create(just(randomValue).single)
           .expectNext(randomValue)
           .verifyComplete()
       }
       "should throw exception if it is empty" in {
-        StepVerifier.create(SMono.empty.single())
+        StepVerifier.create(SMono.empty.single)
           .expectError(classOf[NoSuchElementException])
           .verify()
       }
@@ -1076,7 +1076,7 @@ class SMonoTest extends AnyFreeSpec with Matchers with TestSupport with Idiomati
     ".subscribeContext should pass context properly" in {
       val key = "message"
       val r: SMono[String] = just("Hello")
-          .flatMap(s => SMono.subscribeContext()
+          .flatMap(s => SMono.subscribeContext
           .map(ctx => s"$s ${ctx.get(key)}"))
           .subscriberContext(ctx => ctx.put(key, "World"))
 
@@ -1124,7 +1124,7 @@ class SMonoTest extends AnyFreeSpec with Matchers with TestSupport with Idiomati
 
     ".then" - {
       "without parameter should only replays complete and error signals from this mono" in {
-        StepVerifier.create(just(randomValue).`then`())
+        StepVerifier.create(just(randomValue).`then`)
           .verifyComplete()
       }
       "with other mono should ignore element from this mono and transform its completion signal into emission and " +

--- a/src/test/scala/reactor/core/scala/publisher/ScannableTest.scala
+++ b/src/test/scala/reactor/core/scala/publisher/ScannableTest.scala
@@ -7,7 +7,7 @@ import reactor.core.scala.Scannable
 class ScannableTest extends AnyFreeSpec with Matchers {
   "Scannable" - {
     ".stepName should return a meaningful String representation of this Scannable in its chain of Scannable.parents and Scannable.actuals" in {
-      val scannable: Scannable = Scannable.from(Option(SMono.just(123).onTerminateDetach()))
+      val scannable: Scannable = Scannable.from(Option(SMono.just(123).onTerminateDetach))
       scannable.stepName shouldBe "detach"
     }
   }


### PR DESCRIPTION
This is a breaking change for any code that used `()` on these methods(i.e. `.asJava()`).

However, it removes compiler warnings in the opposite scenario(i.e. `.asJava`),
and makes it clear per Scala conventions when a method will produce side effects.