### PR TITLE
Renamed SMono.subscribeContext to subscriberContext

### DIFF
--- a/src/main/scala/reactor/core/scala/publisher/SMono.scala
+++ b/src/main/scala/reactor/core/scala/publisher/SMono.scala
@@ -1503,6 +1503,9 @@ object SMono extends ScalaConverters {
     * @return a new [[SMono]] emitting current context
     * @see [[SMono.subscribe(CoreSubscriber)]]
     */
+  def subscriberContext: SMono[Context] = JMono.subscriberContext().asScala
+  
+  @deprecated("Use subscriberContext instead")
   def subscribeContext(): SMono[Context] = JMono.subscriberContext().asScala
 
   @deprecated("Use error(Throwable) instead")

--- a/src/test/scala/reactor/core/scala/publisher/SMonoTest.scala
+++ b/src/test/scala/reactor/core/scala/publisher/SMonoTest.scala
@@ -1073,6 +1073,25 @@ class SMonoTest extends AnyFreeSpec with Matchers with TestSupport with Idiomati
       }
     }
 
+    ".subscriberContext should pass context properly" in {
+      val key = "message"
+      val r: SMono[String] = just("Hello")
+          .flatMap(s => SMono.subscriberContext
+          .map(ctx => s"$s ${ctx.get(key)}"))
+          .subscriberContext(ctx => ctx.put(key, "World"))
+
+      StepVerifier.create(r)
+          .expectNext("Hello World")
+          .verifyComplete()
+
+      StepVerifier.create(just(1).map(i => i + 10),
+        StepVerifierOptions.create().withInitialContext(Context.of("foo", "bar")))
+        .expectAccessibleContext()
+        .contains("foo", "bar")
+        .`then`()
+        .expectNext(11)
+        .verifyComplete()
+    }
     ".subscribeContext should pass context properly" in {
       val key = "message"
       val r: SMono[String] = just("Hello")


### PR DESCRIPTION
I'm assuming this was a typo; SFlux already has the correctly-named method.

Per the comments in #66, I've retained the param list on the now-deprecated existing method, but left it off of the new one.