### PR TITLE
Restored Invariance of SFlux/SMono.asJava

### DIFF
--- a/src/main/scala/reactor/core/scala/publisher/SFlux.scala
+++ b/src/main/scala/reactor/core/scala/publisher/SFlux.scala
@@ -19,6 +19,7 @@ import reactor.util.context.Context
 import reactor.util.function.{Tuple3, Tuple4, Tuple5, Tuple6}
 import reactor.util.retry.Retry
 
+import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.mutable
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.Duration.Infinite
@@ -82,7 +83,7 @@ trait SFlux[+T] extends SFluxLike[T] with MapablePublisher[T] with ScalaConverte
     coreFlux.as[P]((t: JFlux[_ <: T]) => transformer(SFlux.fromPublisher(t)))
   }
 
-  final def asJava(): JFlux[_ <: T] = coreFlux
+  final def asJava(): JFlux[T @uncheckedVariance] = coreFlux.asInstanceOf[JFlux[T]]
 
   /**
     * Blocks until the upstream signals its first value or completes.

--- a/src/main/scala/reactor/core/scala/publisher/SMono.scala
+++ b/src/main/scala/reactor/core/scala/publisher/SMono.scala
@@ -14,6 +14,7 @@ import reactor.util.concurrent.Queues.SMALL_BUFFER_SIZE
 import reactor.util.context.Context
 import reactor.util.function.{Tuple2, Tuple3, Tuple4, Tuple5, Tuple6}
 
+import scala.annotation.unchecked.uncheckedVariance
 import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future, Promise}
@@ -86,7 +87,7 @@ trait SMono[+T] extends SMonoLike[T] with MapablePublisher[T] with ScalaConverte
     *
     * @return [[reactor.core.publisher.Mono]]
     */
-  final def asJava(): JMono[_ <: T] = coreMono
+  final def asJava(): JMono[T @uncheckedVariance] = coreMono.asInstanceOf[JMono[T]]
 
   /**
     * Block until a next signal is received, will return null if onComplete, T if onNext, throw a


### PR DESCRIPTION
When adopting v0.7.0, I had to deal with a number of breakages w.r.t. the covariance change (really only `.asJava` was a problem). 
While I was able to work around it in all cases, the resulting code is not as clean as it once was.

After a bit of reflection, I'm of the mind that the change to the `.asJava` method signature was unnecessary.

Consider that other Scala collections are covariant, yet return an invariant type in their `.asJava` methods:
![image](https://user-images.githubusercontent.com/1999162/86277054-ade4cf00-bb9b-11ea-8a54-9548e4cdcf74.png)

And since we're wrapping the Java API anyway, it'll be an ongoing annoyance to not be able to round-trip Scala <--> Java without doing battle with the type system.

This change gets us back to the pre-0.7.0 method signature, while still allowing covariance on the Scala side.

Aspects of this are a bit fuzzy to me, so I'd appreciate input on potential consequences I've overlooked.
