### PR TITLE
Removed deprecated for 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ lazy val scala212 = "2.12.11"
 lazy val scala213 = "2.13.2"
 lazy val supportedScalaVersions = List(scala212, scala213)
 
-ThisBuild / scalaVersion := "2.12.11"
+ThisBuild / scalaVersion := scala212
 
 lazy val root = (project in file("."))
 	.settings(

--- a/src/main/scala-2.12/reactor/core/scala/VersionedScannable.scala
+++ b/src/main/scala-2.12/reactor/core/scala/VersionedScannable.scala
@@ -1,0 +1,27 @@
+package reactor.core.scala
+
+import scala.jdk.CollectionConverters._
+
+trait VersionedScannable { self: Scannable =>
+  def actuals(): Stream[_ <: Scannable] = jScannable.actuals().iterator().asScala.map(js => js: Scannable).toStream
+
+  def inners(): Stream[_ <: Scannable] = jScannable.inners().iterator().asScala.map(js => js: Scannable).toStream
+
+  /**
+    * Return a [[Stream]] navigating the [[org.reactivestreams.Subscription]]
+    * chain (upward).
+    *
+    * @return a [[Stream]] navigating the [[org.reactivestreams.Subscription]]
+    *                   chain (upward)
+    */
+  def parents: Stream[_ <: Scannable] = jScannable.parents().iterator().asScala.map(js => js: Scannable).toStream
+
+  /**
+    * Visit this [[Scannable]] and its [[Scannable.parents()]] and stream all the
+    * observed tags
+    *
+    * @return the stream of tags for this [[Scannable]] and its parents
+    */
+  def tags: Stream[(String, String)] = jScannable.tags().iterator().asScala.map(publisher.tupleTwo2ScalaTuple2).toStream
+
+}

--- a/src/main/scala-2.12/reactor/core/scala/publisher/VersionedFluxProcessor.scala
+++ b/src/main/scala-2.12/reactor/core/scala/publisher/VersionedFluxProcessor.scala
@@ -1,0 +1,9 @@
+package reactor.core.scala.publisher
+
+import reactor.core.scala.{Scannable, VersionedScannable}
+
+import scala.jdk.CollectionConverters._
+
+trait VersionedFluxProcessor[IN, OUT] extends VersionedScannable { self: FluxProcessor[IN, OUT] =>
+  override def inners(): Stream[_ <: Scannable] = jFluxProcessor.inners().iterator().asScala.map(js=> js: Scannable).toStream
+}

--- a/src/main/scala-2.12/reactor/core/scala/publisher/VersionedSFlux.scala
+++ b/src/main/scala-2.12/reactor/core/scala/publisher/VersionedSFlux.scala
@@ -1,0 +1,25 @@
+package reactor.core.scala.publisher
+
+import java.util
+import java.util.{Collection => JCollection, Map => JMap}
+
+import reactor.util.concurrent.Queues.SMALL_BUFFER_SIZE
+
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+
+trait VersionedSFlux[+T] {self: SFlux[T] =>
+  final def collectMultimap[K](keyExtractor: T => K): SMono[Map[K, Traversable[T]]] = collectMultimap(keyExtractor, (t: T) => t, ()=>mutable.HashMap.empty[K, util.Collection[T]])
+
+  final def collectMultimap[K, V](keyExtractor: T => K,
+                                  valueExtractor: T => V,
+                                  mapSupplier: () => mutable.Map[K, util.Collection[V]] = () => mutable.HashMap.empty[K, util.Collection[V]]):
+  SMono[Map[K, Traversable[V]]] =
+    new ReactiveSMono[Map[K, Traversable[V]]](coreFlux.collectMultimap[K, V](keyExtractor,
+      valueExtractor,
+      () => mapSupplier().asJava)
+      .map((m: JMap[K, JCollection[V]]) => m.asScala.mapValues((vs: JCollection[V]) => vs.asScala.toSeq).toMap))
+
+  final def toStream(batchSize: Int = SMALL_BUFFER_SIZE): Stream[T] = coreFlux.toStream(batchSize).iterator().asScala.toStream
+
+}

--- a/src/main/scala-2.12/reactor/core/scala/publisher/VersionedSFluxCompanion.scala
+++ b/src/main/scala-2.12/reactor/core/scala/publisher/VersionedSFluxCompanion.scala
@@ -1,0 +1,8 @@
+package reactor.core.scala.publisher
+
+import reactor.core.publisher.{Flux => JFlux}
+import reactor.core.scala.publisher.versioned._
+
+trait VersionedSFluxCompanion {
+  def fromStream[T](streamSupplier: () => Stream[T]): SFlux[T] = new ReactiveSFlux[T](JFlux.fromStream[T](streamSupplier()))
+}

--- a/src/main/scala-2.12/reactor/core/scala/publisher/versioned/package.scala
+++ b/src/main/scala-2.12/reactor/core/scala/publisher/versioned/package.scala
@@ -1,0 +1,12 @@
+package reactor.core.scala.publisher
+
+import java.util.stream.{StreamSupport, Stream => JStream}
+import java.util.{Spliterator, Spliterators}
+
+import scala.collection.JavaConverters._
+import scala.language.implicitConversions
+
+package object versioned {
+  implicit def scalaStream2JavaStream[T](stream: Stream[T]): JStream[T] = StreamSupport.stream(Spliterators.spliteratorUnknownSize[T](stream.toIterator.asJava, Spliterator.NONNULL), false)
+
+}

--- a/src/main/scala-2.13/reactor/core/scala/VersionedScannable.scala
+++ b/src/main/scala-2.13/reactor/core/scala/VersionedScannable.scala
@@ -1,0 +1,27 @@
+package reactor.core.scala
+
+import scala.jdk.CollectionConverters._
+
+trait VersionedScannable { self: Scannable =>
+  def actuals(): LazyList[_ <: Scannable] = jScannable.actuals().iterator().asScala.map(js => js: Scannable).to(LazyList)
+
+  def inners(): LazyList[_ <: Scannable] = jScannable.inners().iterator().asScala.map(js => js: Scannable).to(LazyList)
+
+  /**
+    * Return a [[Stream]] navigating the [[org.reactivestreams.Subscription]]
+    * chain (upward).
+    *
+    * @return a [[Stream]] navigating the [[org.reactivestreams.Subscription]]
+    *                   chain (upward)
+    */
+  def parents: LazyList[_ <: Scannable] = jScannable.parents().iterator().asScala.map(js => js: Scannable).to(LazyList)
+
+  /**
+    * Visit this [[Scannable]] and its [[Scannable.parents()]] and stream all the
+    * observed tags
+    *
+    * @return the stream of tags for this [[Scannable]] and its parents
+    */
+  def tags: LazyList[(String, String)] = jScannable.tags().iterator().asScala.map(publisher.tupleTwo2ScalaTuple2).to(LazyList)
+
+}

--- a/src/main/scala-2.13/reactor/core/scala/VersionedScannable.scala
+++ b/src/main/scala-2.13/reactor/core/scala/VersionedScannable.scala
@@ -1,20 +1,20 @@
 package reactor.core.scala
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.StreamConverters._
 
 trait VersionedScannable { self: Scannable =>
-  def actuals(): LazyList[_ <: Scannable] = jScannable.actuals().iterator().asScala.map(js => js: Scannable).to(LazyList)
+  def actuals(): LazyList[_ <: Scannable] = jScannable.actuals().toScala(LazyList).map(js => js: Scannable)
 
-  def inners(): LazyList[_ <: Scannable] = jScannable.inners().iterator().asScala.map(js => js: Scannable).to(LazyList)
+  def inners(): LazyList[_ <: Scannable] = jScannable.inners().toScala(LazyList).map(js => js: Scannable)
 
   /**
-    * Return a [[Stream]] navigating the [[org.reactivestreams.Subscription]]
+    * Return a [[LazyList]] navigating the [[org.reactivestreams.Subscription]]
     * chain (upward).
     *
-    * @return a [[Stream]] navigating the [[org.reactivestreams.Subscription]]
+    * @return a [[LazyList]] navigating the [[org.reactivestreams.Subscription]]
     *                   chain (upward)
     */
-  def parents: LazyList[_ <: Scannable] = jScannable.parents().iterator().asScala.map(js => js: Scannable).to(LazyList)
+  def parents: LazyList[_ <: Scannable] = jScannable.parents().toScala(LazyList).map(js => js: Scannable)
 
   /**
     * Visit this [[Scannable]] and its [[Scannable.parents()]] and stream all the
@@ -22,6 +22,6 @@ trait VersionedScannable { self: Scannable =>
     *
     * @return the stream of tags for this [[Scannable]] and its parents
     */
-  def tags: LazyList[(String, String)] = jScannable.tags().iterator().asScala.map(publisher.tupleTwo2ScalaTuple2).to(LazyList)
+  def tags: LazyList[(String, String)] = jScannable.tags().toScala(LazyList).map(publisher.tupleTwo2ScalaTuple2)
 
 }

--- a/src/main/scala-2.13/reactor/core/scala/publisher/VersionedFluxProcessor.scala
+++ b/src/main/scala-2.13/reactor/core/scala/publisher/VersionedFluxProcessor.scala
@@ -1,0 +1,9 @@
+package reactor.core.scala.publisher
+
+import reactor.core.scala.{Scannable, VersionedScannable}
+
+import scala.jdk.CollectionConverters._
+
+trait VersionedFluxProcessor[IN, OUT] extends VersionedScannable { self: FluxProcessor[IN, OUT] =>
+  override def inners(): LazyList[_ <: Scannable] = jFluxProcessor.inners().iterator().asScala.map(js=> js: Scannable).to(LazyList)
+}

--- a/src/main/scala-2.13/reactor/core/scala/publisher/VersionedSFlux.scala
+++ b/src/main/scala-2.13/reactor/core/scala/publisher/VersionedSFlux.scala
@@ -1,0 +1,28 @@
+package reactor.core.scala.publisher
+
+import java.util
+import java.util.{Collection => JCollection, Map => JMap}
+
+import reactor.util.concurrent.Queues.SMALL_BUFFER_SIZE
+
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+
+trait VersionedSFlux[+T] {self: SFlux[T] =>
+  final def collectMultimap[K](keyExtractor: T => K): SMono[Map[K, Iterable[T]]] = collectMultimap(keyExtractor, (t: T) => t, ()=>mutable.HashMap.empty[K, util.Collection[T]])
+
+  final def collectMultimap[K, V](keyExtractor: T => K,
+                                  valueExtractor: T => V,
+                                  mapSupplier: () => mutable.Map[K, util.Collection[V]] = () => mutable.HashMap.empty[K, util.Collection[V]]):
+  SMono[Map[K, Iterable[V]]] =
+    new ReactiveSMono[Map[K, Iterable[V]]](coreFlux.collectMultimap[K, V](keyExtractor,
+      valueExtractor,
+      () => mapSupplier().asJava)
+      .map((m: JMap[K, JCollection[V]]) => m.asScala.view.mapValues((vs: JCollection[V]) => vs.asScala.toSeq).toMap))
+
+  @deprecated("Use toLazyList", since = "0.8.0, 2.13.0")
+  final def toStream(batchSize: Int = SMALL_BUFFER_SIZE): LazyList[T] = toLazyList(batchSize)
+
+  final def toLazyList(batchSize: Int = SMALL_BUFFER_SIZE): LazyList[T] = coreFlux.toStream(batchSize).iterator().asScala.to(LazyList)
+
+}

--- a/src/main/scala-2.13/reactor/core/scala/publisher/VersionedSFluxCompanion.scala
+++ b/src/main/scala-2.13/reactor/core/scala/publisher/VersionedSFluxCompanion.scala
@@ -1,0 +1,8 @@
+package reactor.core.scala.publisher
+
+import reactor.core.publisher.{Flux => JFlux}
+import scala.jdk.StreamConverters._
+
+trait VersionedSFluxCompanion {
+  def fromStream[T](streamSupplier: () => LazyList[T]): SFlux[T] = new ReactiveSFlux[T](JFlux.fromStream[T](streamSupplier().asJavaSeqStream))
+}

--- a/src/main/scala-2.13/reactor/core/scala/publisher/VersionedSFluxCompanion.scala
+++ b/src/main/scala-2.13/reactor/core/scala/publisher/VersionedSFluxCompanion.scala
@@ -4,5 +4,9 @@ import reactor.core.publisher.{Flux => JFlux}
 import scala.jdk.StreamConverters._
 
 trait VersionedSFluxCompanion {
-  def fromStream[T](streamSupplier: () => LazyList[T]): SFlux[T] = new ReactiveSFlux[T](JFlux.fromStream[T](streamSupplier().asJavaSeqStream))
+  @deprecated("Use fromLazyList, will be removed in 1.0.0", "0.8.0")
+  def fromStream[T](streamSupplier: () => Stream[T]): SFlux[T] = fromLazyList(() => streamSupplier().to(LazyList))
+
+  def fromLazyList[T](lazyListSupplier: () => LazyList[T]): SFlux[T] = new ReactiveSFlux[T](JFlux.fromStream[T](lazyListSupplier().asJavaSeqStream))
+
 }

--- a/src/main/scala-2.13/reactor/core/scala/publisher/versioned/package.scala
+++ b/src/main/scala-2.13/reactor/core/scala/publisher/versioned/package.scala
@@ -1,0 +1,10 @@
+package reactor.core.scala.publisher
+
+import java.util.stream.{Stream => JStream}
+
+import scala.language.implicitConversions
+import scala.jdk.StreamConverters._
+
+package object versioned {
+  implicit def scalaStream2JavaStream[T](stream: LazyList[T]): JStream[T] = stream.asJavaSeqStream
+}

--- a/src/main/scala/reactor/core/scala/Scannable.scala
+++ b/src/main/scala/reactor/core/scala/Scannable.scala
@@ -3,18 +3,13 @@ package reactor.core.scala
 import reactor.core.Scannable.Attr
 import reactor.core.{Scannable => JScannable}
 
-import scala.jdk.CollectionConverters._
 import scala.language.implicitConversions
 
 /**
   * Created by winarto on 17/6/17.
   */
-trait Scannable {
+trait Scannable extends VersionedScannable {
   private[scala] def jScannable: JScannable
-
-  def actuals(): Stream[_ <: Scannable] = jScannable.actuals().iterator().asScala.map(js => js: Scannable).toStream
-
-  def inners(): Stream[_ <: Scannable] = jScannable.inners().iterator().asScala.map(js => js: Scannable).toStream
 
   def isScanAvailable: Boolean = jScannable.isScanAvailable
 
@@ -33,15 +28,6 @@ trait Scannable {
   def stepName: String = jScannable.stepName()
 
   /**
-    * Return a [[Stream]] navigating the [[org.reactivestreams.Subscription]]
-    * chain (upward).
-    *
-    * @return a [[Stream]] navigating the [[org.reactivestreams.Subscription]]
-    *                   chain (upward)
-    */
-  def parents: Stream[_ <: Scannable] = jScannable.parents().iterator().asScala.map(js => js: Scannable).toStream
-
-  /**
     * This method is used internally by components to define their key-value mappings
     * in a single place. Although it is ignoring the generic type of the [[Attr]] key,
     * implementors should take care to return values of the correct type, and return
@@ -54,7 +40,7 @@ trait Scannable {
     * @param key a { @link Attr} to resolve for the component.
     * @return the value associated to the key for that specific component, or null if none.
     */
-  def scanUnsafe(key: Attr[_]) = Option(jScannable.scanUnsafe(key))
+  def scanUnsafe(key: Attr[_]): Option[AnyRef] = Option(jScannable.scanUnsafe(key))
 
   /**
     * Introspect a component's specific state [[Attr attribute]], returning an
@@ -78,14 +64,6 @@ trait Scannable {
     * @return a value associated to the key or the provided default if unmatched or unresolved
     */
   def scanOrDefault[T](key: Attr[T], defaultValue: T): T = jScannable.scanOrDefault(key, defaultValue)
-
-  /**
-    * Visit this [[Scannable]] and its [[Scannable.parents()]] and stream all the
-    * observed tags
-    *
-    * @return the stream of tags for this [[Scannable]] and its parents
-    */
-  def tags: Stream[(String, String)] = jScannable.tags().iterator().asScala.map(publisher.tupleTwo2ScalaTuple2).toStream
 }
 
 object Scannable {

--- a/src/main/scala/reactor/core/scala/publisher/FluxProcessor.scala
+++ b/src/main/scala/reactor/core/scala/publisher/FluxProcessor.scala
@@ -17,7 +17,7 @@ import scala.jdk.CollectionConverters._
   * @tparam IN  the input value type
   * @tparam OUT the output value type
   */
-trait FluxProcessor[IN, OUT] extends SFlux[OUT] with Processor[IN, OUT] with Disposable with Scannable {
+trait FluxProcessor[IN, OUT] extends VersionedFluxProcessor[IN, OUT] with  SFlux[OUT] with Processor[IN, OUT] with Disposable with Scannable {
 
   protected def jFluxProcessor: JFluxProcessor[IN, OUT]
 
@@ -62,8 +62,6 @@ trait FluxProcessor[IN, OUT] extends SFlux[OUT] with Processor[IN, OUT] with Dis
     * @return true if terminated with onError
     */
   def hasError: Boolean = jFluxProcessor.hasError
-
-  override def inners(): Stream[_ <: Scannable] = jFluxProcessor.inners().iterator().asScala.map(js=> js: Scannable).toStream
 
   /**
     * Has this upstream finished or "completed" / "failed" ?

--- a/src/main/scala/reactor/core/scala/publisher/package.scala
+++ b/src/main/scala/reactor/core/scala/publisher/package.scala
@@ -2,11 +2,10 @@ package reactor.core.scala
 
 import java.lang.{Iterable => JIterable, Long => JLong}
 import java.time.{Duration => JDuration}
+import java.util.Optional
 import java.util.Optional.empty
 import java.util.concurrent.Callable
 import java.util.function.{BiConsumer, BiFunction, BiPredicate, BooleanSupplier, Consumer, Function, LongConsumer, Predicate, Supplier}
-import java.util.stream.{StreamSupport, Stream => JStream}
-import java.util.{Optional, Spliterator, Spliterators}
 
 import org.reactivestreams.Publisher
 import reactor.core.publisher.{Flux => JFlux}
@@ -81,5 +80,4 @@ package object publisher {
 
   implicit def javaOptional2ScalaOption[T](jOptional: Optional[T]): Option[T] = if(jOptional.isPresent) Some(jOptional.get()) else None
 
-  implicit def scalaStream2JavaStream[T](stream: Stream[T]): JStream[T] = StreamSupport.stream(Spliterators.spliteratorUnknownSize[T](stream.toIterator.asJava, Spliterator.NONNULL), false)
 }

--- a/src/test/scala-2.12/reactor/core/scala/publisher/SFlux212Test.scala
+++ b/src/test/scala-2.12/reactor/core/scala/publisher/SFlux212Test.scala
@@ -1,0 +1,110 @@
+package reactor.core.scala.publisher
+
+import java.io.{File, PrintWriter}
+import java.nio.file.Files
+import java.util
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import reactor.core.scala.Scannable
+import reactor.test.StepVerifier
+
+import scala.collection.mutable
+import scala.io.Source
+
+class SFlux212Test extends AnyFreeSpec with Matchers {
+  "SFlux" - {
+    ".fromStream" - {
+      "with supplier should create flux that emit items contained in the supplier" in {
+        StepVerifier.create(SFlux.fromStream(() => Stream(1, 2, 3)))
+          .expectNext(1, 2, 3)
+          .verifyComplete()
+      }
+    }
+
+    ".using" - {
+      "without eager flag should produce some data" in {
+        val tempFile = Files.createTempFile("fluxtest-", ".tmp")
+        tempFile.toFile.deleteOnExit()
+        new PrintWriter(tempFile.toFile) {
+          write(s"1${sys.props("line.separator")}2")
+          flush()
+          close()
+        }
+
+        StepVerifier.create(
+          SFlux.using[String, File](() => tempFile.toFile, (file: File) => SFlux.fromIterable[String](Source.fromFile(file).getLines().toIterable), (file: File) => {
+            file.delete()
+            ()
+          }))
+          .expectNext("1", "2")
+          .verifyComplete()
+      }
+      "with eager flag should produce some data" in {
+        val tempFile = Files.createTempFile("fluxtest-", ".tmp")
+        tempFile.toFile.deleteOnExit()
+        new PrintWriter(tempFile.toFile) {
+          write(s"1${sys.props("line.separator")}2")
+          flush()
+          close()
+        }
+        StepVerifier.create(
+          SFlux.using[String, File](() => tempFile.toFile, (file: File) => SFlux.fromIterable[String](Source.fromFile(file).getLines().toIterable), (file: File) => {
+            file.delete()
+            ()
+          }, eager = true))
+          .expectNext("1", "2")
+          .verifyComplete()
+      }
+    }
+    "bracketCase" - {
+      "should release all resources properly" in {
+        import java.io.PrintWriter
+        val files = (0 until 5) map(i => {
+          val path = Files.createTempFile(s"bracketCase-$i", ".tmp")
+          val file = path.toFile
+          new PrintWriter(file) { write(s"$i"); close() }
+          file
+        })
+        files.foreach(f => f.exists() shouldBe true)
+        val sf = SFlux.fromIterable(files)
+          .bracketCase(f => {
+            SFlux.just(Source.fromFile(f))
+              .bracket(br => SFlux.fromIterable(br.getLines().toIterable))(_.close())
+          })((file, _) => file.delete())
+        StepVerifier.create(sf)
+          .expectNext("0", "1", "2", "3", "4")
+          .verifyComplete()
+        files.foreach(f => f.exists() shouldBe false)
+      }
+    }
+
+    ".collectMultimap" - {
+      "with keyExtractor, valueExtractor and map supplier should collect the value, extract the key and value from it and put in the provided map" in {
+        val map = mutable.HashMap[Int, util.Collection[Int]]()
+        StepVerifier.create(SFlux.just(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).collectMultimap(i => i % 3, i => i + 6, () => map))
+          .expectNextMatches((m: Map[Int, Traversable[Int]]) => {
+            m shouldBe map.mapValues(vs => vs.toArray().toSeq).toMap
+            m shouldBe Map((0, Seq(9, 12, 15)), (1, Seq(7, 10, 13, 16)), (2, Seq(8, 11, 14)))
+            true
+          })
+          .verifyComplete()
+      }
+    }
+
+    ".tag should tag the Flux and accessible from Scannable" in {
+      val flux = SFlux.just(1, 2, 3).tag("integer", "one, two, three")
+      Scannable.from(Option(flux)).tags shouldBe Stream("integer" -> "one, two, three")
+    }
+
+    ".toStream" - {
+      "should transform this flux into stream" in {
+        SFlux.just(1, 2, 3).toStream() shouldBe Stream(1, 2, 3)
+      }
+      "with batchSize should transform this flux into stream" in {
+        SFlux.just(1, 2, 3).toStream(2) shouldBe Stream(1, 2, 3)
+      }
+    }
+
+  }
+}

--- a/src/test/scala-2.13/reactor/core/scala/publisher/SFlux213Test.scala
+++ b/src/test/scala-2.13/reactor/core/scala/publisher/SFlux213Test.scala
@@ -1,0 +1,119 @@
+package reactor.core.scala.publisher
+
+import java.io.{File, PrintWriter}
+import java.nio.file.Files
+import java.util
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import reactor.core.scala.Scannable
+import reactor.test.StepVerifier
+
+import scala.collection.mutable
+import scala.io.Source
+
+class SFlux213Test extends AnyFreeSpec with Matchers {
+  "SFlux" - {
+    ".fromStream" - {
+      "should create flux that emit items contained in the supplier" in {
+        StepVerifier.create(SFlux.fromStream(() => LazyList(1, 2, 3)))
+          .expectNext(1, 2, 3)
+          .verifyComplete()
+      }
+    }
+
+    ".using" - {
+      "without eager flag should produce some data" in {
+        val tempFile = Files.createTempFile("fluxtest-", ".tmp")
+        tempFile.toFile.deleteOnExit()
+        new PrintWriter(tempFile.toFile) {
+          write(s"1${sys.props("line.separator")}2")
+          flush()
+          close()
+        }
+
+        StepVerifier.create(
+          SFlux.using[String, File](() => tempFile.toFile, (file: File) => SFlux.fromIterable[String](Source.fromFile(file).getLines().iterator.to(Iterable)), (file: File) => {
+            file.delete()
+            ()
+          }))
+          .expectNext("1", "2")
+          .verifyComplete()
+      }
+      "with eager flag should produce some data" in {
+        val tempFile = Files.createTempFile("fluxtest-", ".tmp")
+        tempFile.toFile.deleteOnExit()
+        new PrintWriter(tempFile.toFile) {
+          write(s"1${sys.props("line.separator")}2")
+          flush()
+          close()
+        }
+        StepVerifier.create(
+          SFlux.using[String, File](() => tempFile.toFile, (file: File) => SFlux.fromIterable[String](Source.fromFile(file).getLines().iterator.to(Iterable)), (file: File) => {
+            file.delete()
+            ()
+          }, eager = true))
+          .expectNext("1", "2")
+          .verifyComplete()
+      }
+    }
+
+    ".bracketCase" - {
+      "should release all resources properly" in {
+        import java.io.PrintWriter
+        val files = (0 until 5) map(i => {
+          val path = Files.createTempFile(s"bracketCase-$i", ".tmp")
+          val file = path.toFile
+          new PrintWriter(file) { write(s"$i"); close() }
+          file
+        })
+        files.foreach(f => f.exists() shouldBe true)
+        val sf = SFlux.fromIterable(files)
+          .bracketCase(f => {
+            SFlux.just(Source.fromFile(f))
+              .bracket(br => SFlux.fromIterable(br.getLines().iterator.to(Iterable)))(_.close())
+          })((file, _) => file.delete())
+        StepVerifier.create(sf)
+          .expectNext("0", "1", "2", "3", "4")
+          .verifyComplete()
+        files.foreach(f => f.exists() shouldBe false)
+      }
+    }
+
+    ".collectMultimap" - {
+      "with keyExtractor, valueExtractor and map supplier should collect the value, extract the key and value from it and put in the provided map" in {
+        val map = mutable.HashMap[Int, util.Collection[Int]]()
+        StepVerifier.create(SFlux.just(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).collectMultimap(i => i % 3, i => i + 6, () => map))
+          .expectNextMatches((m: Map[Int, Iterable[Int]]) => {
+            m shouldBe map.view.mapValues(vs => vs.toArray().toSeq).toMap
+            m shouldBe Map((0, Seq(9, 12, 15)), (1, Seq(7, 10, 13, 16)), (2, Seq(8, 11, 14)))
+            true
+          })
+          .verifyComplete()
+      }
+    }
+
+    ".tag should tag the Flux and accessible from Scannable" in {
+      val flux = SFlux.just(1, 2, 3).tag("integer", "one, two, three")
+      Scannable.from(Option(flux)).tags shouldBe LazyList("integer" -> "one, two, three")
+    }
+
+    ".toStream" - {
+      "should transform this flux into stream" in {
+        SFlux.just(1, 2, 3).toStream() shouldBe LazyList(1, 2, 3)
+      }
+      "with batchSize should transform this flux into stream" in {
+        SFlux.just(1, 2, 3).toStream(2) shouldBe LazyList(1, 2, 3)
+      }
+    }
+
+    ".toLazyList" - {
+      "should transform this flux into stream" in {
+        SFlux.just(1, 2, 3).toLazyList() shouldBe LazyList(1, 2, 3)
+      }
+      "with batchSize should transform this flux into stream" in {
+        SFlux.just(1, 2, 3).toLazyList(2) shouldBe LazyList(1, 2, 3)
+      }
+    }
+  }
+}

--- a/src/test/scala-2.13/reactor/core/scala/publisher/SFlux213Test.scala
+++ b/src/test/scala-2.13/reactor/core/scala/publisher/SFlux213Test.scala
@@ -16,10 +16,16 @@ class SFlux213Test extends AnyFreeSpec with Matchers {
   "SFlux" - {
     ".fromStream" - {
       "should create flux that emit items contained in the supplier" in {
-        StepVerifier.create(SFlux.fromStream(() => LazyList(1, 2, 3)))
+        StepVerifier.create(SFlux.fromStream(() => Stream(1, 2, 3)))
           .expectNext(1, 2, 3)
           .verifyComplete()
       }
+      ".fromLazyList" - {
+        "should create flux that emit items contained in the supplier" in {
+          StepVerifier.create(SFlux.fromLazyList(() => LazyList(1, 2, 3)))
+            .expectNext(1, 2, 3)
+            .verifyComplete()
+        }
     }
 
     ".using" - {

--- a/src/test/scala-2.13/reactor/core/scala/publisher/SFlux213Test.scala
+++ b/src/test/scala-2.13/reactor/core/scala/publisher/SFlux213Test.scala
@@ -20,7 +20,8 @@ class SFlux213Test extends AnyFreeSpec with Matchers {
           .expectNext(1, 2, 3)
           .verifyComplete()
       }
-      ".fromLazyList" - {
+    }
+    ".fromLazyList" - {
         "should create flux that emit items contained in the supplier" in {
           StepVerifier.create(SFlux.fromLazyList(() => LazyList(1, 2, 3)))
             .expectNext(1, 2, 3)

--- a/src/test/scala/reactor/core/scala/publisher/SFluxTest.scala
+++ b/src/test/scala/reactor/core/scala/publisher/SFluxTest.scala
@@ -166,14 +166,6 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
         .verifyComplete()
     }
 
-    ".fromStream" - {
-      "with supplier should create flux that emit items contained in the supplier" in {
-        StepVerifier.create(SFlux.fromStream(() => Stream(1, 2, 3)))
-          .expectNext(1, 2, 3)
-          .verifyComplete()
-      }
-    }
-
     ".generate" - {
       "with state supplier and state consumer" in {
         val tempFile = Files.createTempFile("fluxtest-", ".tmp").toFile
@@ -437,41 +429,6 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
         .verifyComplete()
     }
 
-    ".using" - {
-      "without eager flag should produce some data" in {
-        val tempFile = Files.createTempFile("fluxtest-", ".tmp")
-        tempFile.toFile.deleteOnExit()
-        new PrintWriter(tempFile.toFile) {
-          write(s"1${sys.props("line.separator")}2")
-          flush()
-          close()
-        }
-
-        StepVerifier.create(
-          SFlux.using[String, File](() => tempFile.toFile, (file: File) => SFlux.fromIterable[String](Source.fromFile(file).getLines().toIterable), (file: File) => {
-            file.delete()
-            ()
-          }))
-          .expectNext("1", "2")
-          .verifyComplete()
-      }
-      "with eager flag should produce some data" in {
-        val tempFile = Files.createTempFile("fluxtest-", ".tmp")
-        tempFile.toFile.deleteOnExit()
-        new PrintWriter(tempFile.toFile) {
-          write(s"1${sys.props("line.separator")}2")
-          flush()
-          close()
-        }
-        StepVerifier.create(
-          SFlux.using[String, File](() => tempFile.toFile, (file: File) => SFlux.fromIterable[String](Source.fromFile(file).getLines().toIterable), (file: File) => {
-            file.delete()
-            ()
-          }, eager = true))
-          .expectNext("1", "2")
-          .verifyComplete()
-      }
-    }
 
     ".zip" - {
       "with source1, source2 and combinator should combine the data" in {
@@ -585,26 +542,6 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
     }
 
     ".bracketCase" - {
-      "should release all resources properly" in {
-        import java.io.PrintWriter
-        val files = (0 until 5) map(i => {
-          val path = Files.createTempFile(s"bracketCase-$i", ".tmp")
-          val file = path.toFile
-          new PrintWriter(file) { write(s"$i"); close() }
-          file
-        })
-        files.foreach(f => f.exists() shouldBe true)
-        val sf = SFlux.fromIterable(files)
-          .bracketCase(f => {
-            SFlux.just(Source.fromFile(f))
-              .bracket(br => SFlux.fromIterable(br.getLines().toIterable))(_.close())
-          })((file, _) => file.delete())
-        StepVerifier.create(sf)
-          .expectNext("0", "1", "2", "3", "4")
-          .verifyComplete()
-        files.foreach(f => f.exists() shouldBe false)
-      }
-
       "should handle ExitCase.error" - {
         "when the error happens inside the generated flux" in {
           import java.io.PrintWriter
@@ -939,16 +876,6 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
       "with keyExtractor and valueExtractor should collect the value, extract the key and value from it" in {
         StepVerifier.create(SFlux.just(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).collectMultimap(i => i % 3, i => i + 6))
           .expectNext(Map((0, Seq(9, 12, 15)), (1, Seq(7, 10, 13, 16)), (2, Seq(8, 11, 14))))
-          .verifyComplete()
-      }
-      "with keyExtractor, valueExtractor and map supplier should collect the value, extract the key and value from it and put in the provided map" in {
-        val map = mutable.HashMap[Int, util.Collection[Int]]()
-        StepVerifier.create(SFlux.just(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).collectMultimap(i => i % 3, i => i + 6, () => map))
-          .expectNextMatches((m: Map[Int, Traversable[Int]]) => {
-            m shouldBe map.mapValues(vs => vs.toArray().toSeq).toMap
-            m shouldBe Map((0, Seq(9, 12, 15)), (1, Seq(7, 10, 13, 16)), (2, Seq(8, 11, 14)))
-            true
-          })
           .verifyComplete()
       }
     }
@@ -2130,11 +2057,6 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
         .verifyComplete()
     }
 
-    ".tag should tag the Flux and accessible from Scannable" in {
-      val flux = SFlux.just(1, 2, 3).tag("integer", "one, two, three")
-      Scannable.from(Option(flux)).tags shouldBe Stream("integer" -> "one, two, three")
-    }
-
     ".tail should return flux that exclude the head" in {
       StepVerifier.create(SFlux.just(1, 2, 3, 4, 5).tail)
         .expectNext(2, 3, 4, 5)
@@ -2252,15 +2174,6 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
         val list = SFlux.just(1, 2, 3)
           .toIterable[Int](1, Option(Queues.get(1))).toList
         list shouldBe Iterable(1, 2, 3)
-      }
-    }
-
-    ".toStream" - {
-      "should transform this flux into stream" in {
-        SFlux.just(1, 2, 3).toStream() shouldBe Stream(1, 2, 3)
-      }
-      "with batchSize should transform this flux into stream" in {
-        SFlux.just(1, 2, 3).toStream(2) shouldBe Stream(1, 2, 3)
       }
     }
 


### PR DESCRIPTION
This PR will remove the deprecated caused by upgrade to 2.13
If 2.13 is used, all operators that use parameter or return deprecated classes in 2.13 will be updated to use what 2.13 is suggested, such as `LazyList` instead of `Stream`, `Iterable` rather than `Traversable`, etc