### PR TITLE
Removing cats-effect which was effectively was only to get ExitCase.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,6 @@ val mockitoInline = "org.mockito" % "mockito-inline" % "3.3.3" % "test"
 val mockitoScala = "org.mockito" %% "mockito-scala" % "1.14.3" % "test"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.1.2" % "test"
 val reactorTest = "io.projectreactor" % "reactor-test" % reactorVersion % "test"
-val catsEffect =  "org.typelevel" %% "cats-effect" % "2.1.3"
 
 //Scala versions for cross compiling
 lazy val scala212 = "2.12.11"
@@ -26,8 +25,7 @@ lazy val root = (project in file("."))
 		libraryDependencies += mockitoScala,
 		libraryDependencies += scalaTest,
 		libraryDependencies += reactorTest,
-		libraryDependencies += mockitoInline,
-		libraryDependencies += catsEffect
+		libraryDependencies += mockitoInline
 	)
 
 // Prevent test being executed in parallel as it may failed for the Scheduler and Virtual Scheduler

--- a/src/main/scala/reactor/core/scala/publisher/ExitCondition.scala
+++ b/src/main/scala/reactor/core/scala/publisher/ExitCondition.scala
@@ -1,0 +1,9 @@
+package reactor.core.scala.publisher
+
+trait ExitCondition
+
+case object Completed extends ExitCondition
+
+case object Cancelled extends ExitCondition
+
+case class Error(ex: Throwable) extends ExitCondition

--- a/src/test/scala-2.12/reactor/core/scala/publisher/SFlux212Test.scala
+++ b/src/test/scala-2.12/reactor/core/scala/publisher/SFlux212Test.scala
@@ -57,7 +57,7 @@ class SFlux212Test extends AnyFreeSpec with Matchers {
           .verifyComplete()
       }
     }
-    "bracketCase" - {
+    "usingWhen" - {
       "should release all resources properly" in {
         import java.io.PrintWriter
         val files = (0 until 5) map(i => {
@@ -68,9 +68,9 @@ class SFlux212Test extends AnyFreeSpec with Matchers {
         })
         files.foreach(f => f.exists() shouldBe true)
         val sf = SFlux.fromIterable(files)
-          .bracketCase(f => {
+          .usingWhen(f => {
             SFlux.just(Source.fromFile(f))
-              .bracket(br => SFlux.fromIterable(br.getLines().toIterable))(_.close())
+              .using(br => SFlux.fromIterable(br.getLines().toIterable))(_.close())
           })((file, _) => file.delete())
         StepVerifier.create(sf)
           .expectNext("0", "1", "2", "3", "4")

--- a/src/test/scala-2.13/reactor/core/scala/publisher/SFlux213Test.scala
+++ b/src/test/scala-2.13/reactor/core/scala/publisher/SFlux213Test.scala
@@ -65,7 +65,7 @@ class SFlux213Test extends AnyFreeSpec with Matchers {
       }
     }
 
-    ".bracketCase" - {
+    ".usingWhen" - {
       "should release all resources properly" in {
         import java.io.PrintWriter
         val files = (0 until 5) map(i => {
@@ -76,9 +76,9 @@ class SFlux213Test extends AnyFreeSpec with Matchers {
         })
         files.foreach(f => f.exists() shouldBe true)
         val sf = SFlux.fromIterable(files)
-          .bracketCase(f => {
+          .usingWhen(f => {
             SFlux.just(Source.fromFile(f))
-              .bracket(br => SFlux.fromIterable(br.getLines().iterator.to(Iterable)))(_.close())
+              .using(br => SFlux.fromIterable(br.getLines().iterator.to(Iterable)))(_.close())
           })((file, _) => file.delete())
         StepVerifier.create(sf)
           .expectNext("0", "1", "2", "3", "4")

--- a/src/test/scala/reactor/core/scala/publisher/SFluxTest.scala
+++ b/src/test/scala/reactor/core/scala/publisher/SFluxTest.scala
@@ -8,7 +8,6 @@ import java.util.concurrent.Callable
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong, AtomicReference}
 import java.util.function.Consumer
 
-import cats.effect.ExitCase.Error
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.mockito.{ArgumentMatchersSugar, IdiomaticMockito}
@@ -524,7 +523,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
       }
     }
 
-    ".bracket should always release all resources properly" in {
+    ".using should always release all resources properly" in {
       import java.io.PrintWriter
       val files = (0 until 1) map(i => {
         val path = Files.createTempFile(s"bracketCase-$i", ".tmp")
@@ -534,15 +533,15 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
       })
       files.foreach(f => f.exists() shouldBe true)
       val sf = SFlux.fromIterable(files)
-        .bracket(_ => SFlux.error(new RuntimeException("Always throw exception")))(file => file.delete())
+        .using(_ => SFlux.error(new RuntimeException("Always throw exception")))(file => file.delete())
       StepVerifier.create(sf)
         .expectError(classOf[RuntimeException])
         .verify()
       files.foreach(f => f.exists() shouldBe false)
     }
 
-    ".bracketCase" - {
-      "should handle ExitCase.error" - {
+    ".usingWhen" - {
+      "should handle ExitCondition error" - {
         "when the error happens inside the generated flux" in {
           import java.io.PrintWriter
           val files = (0 until 5) map(i => {
@@ -554,7 +553,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
           try {
             files.foreach(f => f.exists() shouldBe true)
             val sf = SFlux.fromIterable(files)
-              .bracketCase(_ => {
+              .usingWhen(_ => {
                 SFlux.error(new RuntimeException("Always throw exception"))
               })((file, exitCase) => {
                 exitCase match {
@@ -582,7 +581,7 @@ class SFluxTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks
         try {
           files.foreach(f => f.exists() shouldBe true)
           val sf = SFlux.fromIterable(files)
-            .bracketCase(_ => throw new RuntimeException)((file, exitCase) => {
+            .usingWhen(_ => throw new RuntimeException)((file, exitCase) => {
               exitCase match {
                 case Error(_) => ()
                 case _ => file.delete()


### PR DESCRIPTION
Retaining the behavior of bracket and bracketCase but they're renamed to using and usingWhen. The ExitCase from cats-effect is replaced by ExitCondition so the operator can retain the original behavior.

@jpork Can you check if this is ok?